### PR TITLE
fold docblocks above classes like those above functions

### DIFF
--- a/ftplugin/php/foldexpr.vim
+++ b/ftplugin/php/foldexpr.vim
@@ -107,7 +107,7 @@ function! GetPhpFold(lnum)
         elseif line =~? '\v^\s*\*/@!' && IsDocBlock(a:lnum-1)
             return IndentLevel(a:lnum)+1
         elseif line =~? '\v^\s*\*/'
-            if b:phpfold_doc_with_funcs && getline(a:lnum+1) =~?  '\v\s*(abstract\s+|public\s+|private\s+|static\s+|private\s+)*function\s+(\k|\()'
+            if b:phpfold_doc_with_funcs && getline(a:lnum+1) =~?  '\v\s*(abstract\s+|public\s+|private\s+|static\s+|private\s+)*(class\s+|function\s+(\k|\())'
                 return IndentLevel(a:lnum)+1
             else
                 return '<' . (IndentLevel(a:lnum)+1)


### PR DESCRIPTION
Disclaimer: This is the first time I've written any vim script and I am not sure the regex is 100% correct.

All I tried to do is fold docblocks above classes like those above functions. There may be more that should be in the regex to make it work in all cases, but it works for everything I've tried so far.

Also: thank you for writing this and for making it publicly available! I was previously using phpfolding.vim and I really like the folding style of this plugin, and it seems to handle different coding styles better.
