### PR TITLE
Change variables from b: to g:

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ Vim folding for PHP with `foldexpr`
 Configuration
 -------------
 
-- `b:phpfold_use = 1` - Fold groups of use statements in the global scope.
-- `b:phpfold_group_iftry = 0` - Fold if/elseif/else and try/catch/finally blocks as a group, rather than each part separate.
-- `b:phpfold_group_args = 1` - Group function arguments split across multiple lines into their own fold.
-- `b:phpfold_group_case = 1` - Fold case and default blocks inside switches.
-- `b:phpfold_heredocs = 1` - Fold HEREDOCs and NOWDOCs.
-- `b:phpfold_docblocks = 1` - Fold DocBlocks.
-- `b:phpfold_doc_with_funcs = 1` - Fold DocBlocks. Overrides `b:phpfold_docblocks`.
-- `b:phpfold_text = 1` - Enable the custom `foldtext` option.
-- `b:phpfold_text_right_lines = 1` - Display the line count on the right instead of the left.
-- `b:phpfold_text_percent = 0` - Display the percentage of lines the fold represents.
+- `g:phpfold_use = 1` - Fold groups of use statements in the global scope.
+- `g:phpfold_group_iftry = 0` - Fold if/elseif/else and try/catch/finally blocks as a group, rather than each part separate.
+- `g:phpfold_group_args = 1` - Group function arguments split across multiple lines into their own fold.
+- `g:phpfold_group_case = 1` - Fold case and default blocks inside switches.
+- `g:phpfold_heredocs = 1` - Fold HEREDOCs and NOWDOCs.
+- `g:phpfold_docblocks = 1` - Fold DocBlocks.
+- `g:phpfold_doc_with_funcs = 1` - Fold DocBlocks. Overrides `g:phpfold_docblocks`.
+- `g:phpfold_text = 1` - Enable the custom `foldtext` option.
+- `g:phpfold_text_right_lines = 1` - Display the line count on the right instead of the left.
+- `g:phpfold_text_percent = 0` - Display the percentage of lines the fold represents.
 
 Installation
 ------------
@@ -36,10 +36,10 @@ Installation
 
 Option Effects
 --------------
-There are two options for customizing how the fold text displays: `b:phpfold_text_right_lines` and `b:phpfold_text_percent`.
+There are two options for customizing how the fold text displays: `g:phpfold_text_right_lines` and `g:phpfold_text_percent`.
 
-When `b:phpfold_text_right_lines` is true, the number of lines folded along with the dashes that indicate the fold level are aligned on the right side of the screen.
-*`b:phpfold_text_right_lines = 0`:*
+When `g:phpfold_text_right_lines` is true, the number of lines folded along with the dashes that indicate the fold level are aligned on the right side of the screen.
+*`g:phpfold_text_right_lines = 0`:*
 ```
 class ClassName
 {
@@ -49,7 +49,7 @@ class ClassName
 }
 ```
 
-*`b:phpfold_text_right_lines = 1`:*
+*`g:phpfold_text_right_lines = 1`:*
 ```
 class ClassName
 {
@@ -59,8 +59,8 @@ class ClassName
 }
 ```
 
-When `b:phpfold_text_percent` is true, the percentage of the total lines the fold represents is displayed alongside the line count:
-*`b:phpfold_text_right_lines = 0`:*
+When `g:phpfold_text_percent` is true, the percentage of the total lines the fold represents is displayed alongside the line count:
+*`g:phpfold_text_right_lines = 0`:*
 ```
 class ClassName
 {
@@ -70,7 +70,7 @@ class ClassName
 }
 ```
 
-*`b:phpfold_text_right_lines = 1`:*
+*`g:phpfold_text_right_lines = 1`:*
 ```
 class ClassName
 {
@@ -85,7 +85,7 @@ Folding Examples
 ----------------
 
 ### Namespaces alias and imports
-When `b:phpfold_use` is enabled, consecutive `use` statements become folded.
+When `g:phpfold_use` is enabled, consecutive `use` statements become folded.
 
 *Given:*
 ```
@@ -129,7 +129,7 @@ class ClassName extends ParentClass implements
 ```
 
 ### Methods
-When `b:phpfold_doc_with_funcs` is false, methods are folded from the `function` keyword to the method's closing `}`.
+When `g:phpfold_doc_with_funcs` is false, methods are folded from the `function` keyword to the method's closing `}`.
 
 *Given:*
 ```
@@ -158,10 +158,10 @@ class ClassName
 }
 ```
 
-See [DocBlocks] for how `b:phpfold_doc_with_funcs` works when true.
+See [DocBlocks] for how `g:phpfold_doc_with_funcs` works when true.
 
 ### Method Arguments
-When method arguments are listed on multiple lines and `b:phpfold_group_args` is true, the argument list is folded an additional level.
+When method arguments are listed on multiple lines and `g:phpfold_group_args` is true, the argument list is folded an additional level.
 
 *Given:*
 ```
@@ -223,7 +223,7 @@ $foo->bar(
 ```
 
 ### If...Elseif...Else Statements
-When `b:phpfold_group_iftry` is false, `if`, `elseif`, and `else` statements are folded individually.
+When `g:phpfold_group_iftry` is false, `if`, `elseif`, and `else` statements are folded individually.
 
 *Given:*
 ```
@@ -250,7 +250,7 @@ if ($expr1) {
 +- 3 lines: else {...}--------------
 ```
 
-When `b:phpfold_group_iftry` is true, `if`, `elseif`, and `else` statements are folded as a group.
+When `g:phpfold_group_iftry` is true, `if`, `elseif`, and `else` statements are folded as a group.
 
 *Given:*
 ```
@@ -419,7 +419,7 @@ foreach ($iterable as $key => $value) {
 ```
 
 ### Try, Catch
-When `b:phpfold_group_iftry` is false, `try`, `catch`, and `finally` statements are folded individually.
+When `g:phpfold_group_iftry` is false, `try`, `catch`, and `finally` statements are folded individually.
 
 *Given:*
 ```
@@ -450,7 +450,7 @@ try {
 +- 3 lines: finally {...}--------------------------
 ```
 
-When `b:phpfold_group_iftry` is true, `try`, `catch`, and `finally` statements are folded as a group.
+When `g:phpfold_group_iftry` is true, `try`, `catch`, and `finally` statements are folded as a group.
 
 *Given:*
 ```
@@ -512,7 +512,7 @@ $closureWithArgsAndVars = function ($arg1) use ($var1) {
 ```
 
 ### Closure Arguments and Variables
-If `b:phpfold_group_args` is true, then when argument and variable lists are split across multiple lines they are folded an additional level individually.
+If `g:phpfold_group_args` is true, then when argument and variable lists are split across multiple lines they are folded an additional level individually.
 
 *Given:*
 ```
@@ -618,7 +618,7 @@ $array = [
 ```
 
 ### DockBlocks
-When `b:phpfold_docblocks` is enabled and `b:phpfold_doc_with_funcs` is disabled `/** */` comment blocks are folded from the `/**` to the `*/`.
+When `g:phpfold_docblocks` is enabled and `g:phpfold_doc_with_funcs` is disabled `/** */` comment blocks are folded from the `/**` to the `*/`.
 
 *Given:*
 ```
@@ -646,7 +646,7 @@ When `b:phpfold_docblocks` is enabled and `b:phpfold_doc_with_funcs` is disabled
 +- 4 lines: DocBlock Summary that spans multiple lines.---
 ```
 
-If `b:phpfold_doc_with_funcs` is enabled, the fold begins with `/**` and ends with the function's `}`.
+If `g:phpfold_doc_with_funcs` is enabled, the fold begins with `/**` and ends with the function's `}`.
 
 *Given:*
 ```

--- a/ftplugin/php/foldexpr.vim
+++ b/ftplugin/php/foldexpr.vim
@@ -4,15 +4,15 @@
 " Maintainer: Jake Soward <swekaj@gmail.com>
 "
 " Options: 
-"           b:phpfold_use = 1            - Fold groups of use statements in the global scope.
-"           b:phpfold_group_iftry = 0    - Fold if/elseif/else and try/catch/finally
+"           g:phpfold_use = 1            - Fold groups of use statements in the global scope.
+"           g:phpfold_group_iftry = 0    - Fold if/elseif/else and try/catch/finally
 "                                          blocks as a group, rather than each part separate.
-"           b:phpfold_group_args = 1     - Group function arguments split across multiple
+"           g:phpfold_group_args = 1     - Group function arguments split across multiple
 "                                          lines into their own fold.
-"           b:phpfold_group_case = 1     - Fold case and default blocks inside switches.
-"           b:phpfold_heredocs = 1       - Fold HEREDOCs and NOWDOCs.
-"           b:phpfold_docblocks = 1      - Fold DocBlocks.
-"           b:phpfold_doc_with_funcs = 1 - Fold DocBlocks. Overrides b:phpfold_docblocks.
+"           g:phpfold_group_case = 1     - Fold case and default blocks inside switches.
+"           g:phpfold_heredocs = 1       - Fold HEREDOCs and NOWDOCs.
+"           g:phpfold_docblocks = 1      - Fold DocBlocks.
+"           g:phpfold_doc_with_funcs = 1 - Fold DocBlocks. Overrides g:phpfold_docblocks.
 "
 " Known Bugs:
 "  - In switch statements, the closing } is included in the fold of the last case or 
@@ -20,28 +20,28 @@
 setlocal foldmethod=expr
 setlocal foldexpr=GetPhpFold(v:lnum)
 
-if !exists('b:phpfold_use')
-    let b:phpfold_use = 1
+if !exists('g:phpfold_use')
+    let g:phpfold_use = 1
 endif
-if !exists('b:phpfold_group_iftry')
-    let b:phpfold_group_iftry = 0
+if !exists('g:phpfold_group_iftry')
+    let g:phpfold_group_iftry = 0
 endif
-if !exists('b:phpfold_group_args')
-    let b:phpfold_group_args = 1
+if !exists('g:phpfold_group_args')
+    let g:phpfold_group_args = 1
 endif
-if !exists('b:phpfold_heredocs')
-    let b:phpfold_heredocs = 1
+if !exists('g:phpfold_heredocs')
+    let g:phpfold_heredocs = 1
 endif
-if !exists('b:phpfold_docblocks')
-    let b:phpfold_docblocks = 1
+if !exists('g:phpfold_docblocks')
+    let g:phpfold_docblocks = 1
 endif
-if !exists('b:phpfold_doc_with_funcs')
-    let b:phpfold_doc_with_funcs = 1
+if !exists('g:phpfold_doc_with_funcs')
+    let g:phpfold_doc_with_funcs = 1
 endif
 
 " If we want to fold functions with their blocks, we have to fold the blocks.
-if b:phpfold_doc_with_funcs
-    let b:phpfold_docblocks = 1
+if g:phpfold_doc_with_funcs
+    let g:phpfold_docblocks = 1
 endif
 
 function! GetPhpFold(lnum)
@@ -53,7 +53,7 @@ function! GetPhpFold(lnum)
         return '='
     endif
 
-    if b:phpfold_use
+    if g:phpfold_use
         " Fold blocks of 'use' statements that have no indentation.
         " i.e. namespace imports
         if line =~? '\v^use\s+' && getline(a:lnum+1) =~? '\v^(use\s+)@!'
@@ -66,7 +66,7 @@ function! GetPhpFold(lnum)
 
     " handle class methods and independent functions
     if line =~? '\v\s*(abstract\s+|public\s+|private\s+|static\s+|private\s+)*function\s+(\k|\()' && line !~? ';$'
-        if b:phpfold_doc_with_funcs
+        if g:phpfold_doc_with_funcs
             return IndentLevel(a:lnum)+1
         else
             return '>'.(IndentLevel(a:lnum)+1)
@@ -92,7 +92,7 @@ function! GetPhpFold(lnum)
         return '<' . (IndentLevel(a:lnum)+1)
     endif
 
-    if !b:phpfold_group_iftry
+    if !g:phpfold_group_iftry
         " If the next line is followed by an opening else, catch, or finally statement, then this 
         " line closes the current fold so that the else/catch/finally can open a new one.
         if getline(a:lnum+1) =~? '\v}\s*(else|catch|finally)'
@@ -100,14 +100,14 @@ function! GetPhpFold(lnum)
         endif
     endif
 
-    if b:phpfold_docblocks
+    if g:phpfold_docblocks
         " Cause indented multi-line comments (/* */) to be folded.
         if line =~? '\v^\s*/\*\*' && line !~? '\*/'
             return '>'.(IndentLevel(a:lnum)+1)
         elseif line =~? '\v^\s*\*/@!' && IsDocBlock(a:lnum-1)
             return IndentLevel(a:lnum)+1
         elseif line =~? '\v^\s*\*/'
-            if b:phpfold_doc_with_funcs && getline(a:lnum+1) =~?  '\v\s*(abstract\s+|public\s+|private\s+|static\s+|private\s+)*function\s+(\k|\()'
+            if g:phpfold_doc_with_funcs && getline(a:lnum+1) =~?  '\v\s*(abstract\s+|public\s+|private\s+|static\s+|private\s+)*function\s+(\k|\()'
                 return IndentLevel(a:lnum)+1
             else
                 return '<' . (IndentLevel(a:lnum)+1)
@@ -115,7 +115,7 @@ function! GetPhpFold(lnum)
         endif
     endif
 
-    if b:phpfold_group_args
+    if g:phpfold_group_args
         " Increase the foldlevel by 1 for function and closure arguments and use vars that are on
         " multiple lines.
         let prevClassFunc = FindPrevClassFunc(a:lnum)
@@ -130,7 +130,7 @@ function! GetPhpFold(lnum)
 
     " If the line has an open ( ) or [ ] pair, it probably starts a fold
     if line =~? '\v(\(|\[)[^\)\]]*$' 
-        if b:phpfold_group_iftry && line =~? '\v}\s*(elseif|catch)'
+        if g:phpfold_group_iftry && line =~? '\v}\s*(elseif|catch)'
             " But don't start a fold if we're grouping if/elseif/else and try/catch
             return IndentLevel(a:lnum)+1
         else
@@ -151,7 +151,7 @@ function! GetPhpFold(lnum)
         endif
     endif
 
-    if b:phpfold_heredocs
+    if g:phpfold_heredocs
         " Fold the here and now docs
         if line =~? "<<<[a-zA-Z_][a-zA-Z0-9_]*$"
             return '>'.(IndentLevel(a:lnum)+1)

--- a/ftplugin/php/foldtext.vim
+++ b/ftplugin/php/foldtext.vim
@@ -4,24 +4,24 @@
 " Maintainer: Jake Soward <swekaj@gmail.com>
 "
 " Options: 
-"           b:phpfold_text             = 1 - Enable custom foldtext() function
-"           b:phpfold_text_right_lines = 0 - Display the line count on the right
+"           g:phpfold_text             = 1 - Enable custom foldtext() function
+"           g:phpfold_text_right_lines = 0 - Display the line count on the right
 "                                            instead of the left.
-"           b:phpfold_text_percent     = 0 - Display the percentage of lines the
+"           g:phpfold_text_percent     = 0 - Display the percentage of lines the
 "                                            fold represents.
 "
-if exists('b:phpfold_text') && !b:phpfold_text
+if exists('g:phpfold_text') && !g:phpfold_text
     finish
 endif
 
 setlocal foldtext=GetPhpFoldText()
 
-if !exists('b:phpfold_text_right_lines')
-    let b:phpfold_text_right_lines = 0
+if !exists('g:phpfold_text_right_lines')
+    let g:phpfold_text_right_lines = 0
 endif
 
-if !exists('b:phpfold_text_percent')
-    let b:phpfold_text_percent = 0
+if !exists('g:phpfold_text_percent')
+    let g:phpfold_text_percent = 0
 endif
 
 function! GetPhpFoldText()
@@ -31,7 +31,7 @@ function! GetPhpFoldText()
 
     if line =~? '\v^\s*/\*\*?\s*$' " Comments
         " If the DocBlocks are being folded with the function they document, include the function signature in the foldtext.
-        if b:phpfold_doc_with_funcs
+        if g:phpfold_doc_with_funcs
             let funcline = FindNextFunc(v:foldstart)
             if funcline > 0
                 let text .= ExtractFuncName(funcline) . '{...}'
@@ -143,14 +143,14 @@ function! GetPhpFoldText()
     let lines = v:foldend-v:foldstart+1
 
     let percentage = ''
-    if b:phpfold_text_percent
+    if g:phpfold_text_percent
         let percentage = printf(" [% 4.1f%%]", (lines*1.0)/line('$')*100)
     endif
 
     let endtext = printf(" % *d lines", NumColWidth(1), lines)
 
     " Start off with the normal, the fold-level dashes and number of lines in the fold.
-    if !b:phpfold_text_right_lines
+    if !g:phpfold_text_right_lines
         let text = '+' . v:folddashes . endtext . percentage . ': ' . text
     else
         " Place the fold-level dashes and number of lines in fold on the right


### PR DESCRIPTION
Not sure if you'd want this, so feel free to close this PR if you'd rather keep them on the buffer. I don't mind keeping my fork open for me to just use.

I had a problem where when I opened a new file from NERDTree, php-foldexpr didn't know anything about my previous buffer settings.

Love the plugin by the way-nice job!